### PR TITLE
fixed Javascript Error

### DIFF
--- a/mm_hidefields/mm_hidefields.php
+++ b/mm_hidefields/mm_hidefields.php
@@ -37,7 +37,7 @@ function mm_hideFields($fields, $roles = '', $templates = ''){
 				break;
 				
 				case 'metatags':
-					$output .= '$j("select[name*\'=metatags\']").parent("td").hide()'."\n";
+					$output .= '$j("select[name*=\'metatags\']").parent("td").hide()'."\n";
 				break;
 				
 				case 'hidemenu':


### PR DESCRIPTION
line 40 causes the following error when editing a page:

"ManagerManager: An error has occurred: Error - Syntax error, unrecognized expression: select[name*'=metatags']"

now its changed to select[name*='metatags'] and everything allright again